### PR TITLE
Wrap component log string for ESPHome 2026.1 compatibility

### DIFF
--- a/components/dali/esphome_dali.cpp
+++ b/components/dali/esphome_dali.cpp
@@ -188,7 +188,7 @@ void DaliBusComponent::create_light_component(short_addr_t short_addr, uint32_t 
     // NOTE: Not freeing these strings, they will be owned by LightState.
 
     auto* light_state = new light::LightState { dali_light };
-    light_state->set_component_source("light");
+    light_state->set_component_source(LOG_STR("light"));
     App.register_light(light_state);
     App.register_component(light_state);
     light_state->set_name(name);


### PR DESCRIPTION
This change allows me to compile the component on ESPHome 2026.1.